### PR TITLE
Testing

### DIFF
--- a/lib/createProjectFiles.js
+++ b/lib/createProjectFiles.js
@@ -4,10 +4,10 @@ import path from "path";
 import rootDir from "../utils/rootDir.js";
 import { shellCommandExecuter } from "./commandsExecuter.js";
 
-const TEMPLATE_DEFAULT_PATH_JS = (moduleType) => {
+export const templateDefaultPathJs = (moduleType) => {
   return path.join(rootDir, "Templates", "Js", moduleType);
 };
-const TEMPLATE_DEFAULT_PATH_TS = path.join(rootDir, "Templates", "Ts");
+export const templateDefaultPathTs = path.join(rootDir, "Templates", "Ts");
 
 export const createProjectFiles = async (
   projectName,
@@ -24,9 +24,9 @@ export const createProjectFiles = async (
     //create project directories and files
     CreatingSpinner.start();
     if (language == "js") {
-      await createTemplate(TEMPLATE_DEFAULT_PATH_JS(moduleType), projectName);
+      await createTemplate(templateDefaultPathJs(moduleType), projectName);
     } else if (language == "ts") {
-      await createTemplate(TEMPLATE_DEFAULT_PATH_TS, projectName);
+      await createTemplate(templateDefaultPathTs, projectName);
     }
 
     //create package.json file
@@ -108,7 +108,7 @@ export const createProjectFiles = async (
   }
 };
 
-async function packageJsonGenerator(dir, packageObject) {
+export async function packageJsonGenerator(dir, packageObject) {
   try {
     await fs.writeFile(
       dir + "/package.json",
@@ -119,7 +119,7 @@ async function packageJsonGenerator(dir, packageObject) {
   }
 }
 
-async function createTemplate(templatePath, projectPath) {
+export async function createTemplate(templatePath, projectPath) {
   try {
     const files = await fs.readdir(templatePath);
     await fs.mkdir(projectPath);
@@ -135,6 +135,7 @@ async function createTemplate(templatePath, projectPath) {
       }
     }
   } catch (error) {
+    console.log("error");
     throw new Error(error);
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
   "bin": {
     "et": "./bin/ex-tool.js"
   },
+  "scripts": {
+    "test:dev": "npx vitest dev",
+    "test:ci": "npx vitest run"
+  },
   "type": "module",
   "dependencies": {
     "chalk": "^4.1.2",
@@ -33,6 +37,7 @@
     "ora": "^6.3.1"
   },
   "devDependencies": {
-    "eslint": "^8.45.0"
+    "eslint": "^8.45.0",
+    "vitest": "^0.33.0"
   }
 }

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -1,0 +1,7 @@
+import path from "path";
+import { fileURLToPath } from "url";
+
+export const testDir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "/temp"
+);

--- a/tests/createProjectFiles.test.ts
+++ b/tests/createProjectFiles.test.ts
@@ -1,0 +1,50 @@
+import * as fs from "fs";
+import path from "path";
+import { afterAll, describe, expect, it } from "vitest";
+import { packageEjs } from "../Templates/packagesTemp";
+import {
+  createTemplate,
+  packageJsonGenerator,
+  templateDefaultPathJs,
+  templateDefaultPathTs,
+} from "../lib/createProjectFiles";
+import { testDir } from "./constants";
+
+const mjsProjectPath = path.join(testDir, "/test_mjs");
+const cjsProjectPath = path.join(testDir, "/test_ejs");
+const tsProjectPath = path.join(testDir, "/test_ts");
+
+describe("test creating project files", () => {
+  it.concurrent("should generate package json", async () => {
+    await packageJsonGenerator(testDir, packageEjs);
+    expect(fs.existsSync(path.join(testDir, "/package.json"))).toBeTruthy();
+  });
+
+  it.concurrent("should create mjs template", async () => {
+    await createTemplate(templateDefaultPathJs("mjs"), mjsProjectPath);
+    expect(fs.existsSync(mjsProjectPath)).toBeTruthy();
+  });
+
+  it.concurrent("should create cjs template", async () => {
+    await createTemplate(templateDefaultPathJs("cjs"), cjsProjectPath);
+    expect(fs.existsSync(cjsProjectPath)).toBeTruthy();
+  });
+
+  it.concurrent("should create ts template", async () => {
+    await createTemplate(templateDefaultPathTs, tsProjectPath);
+    expect(fs.existsSync(tsProjectPath)).toBeTruthy();
+  });
+
+  it.concurrent("should fail folder already exists", async () => {
+    await expect(() =>
+      createTemplate(templateDefaultPathTs, tsProjectPath)
+    ).rejects.toThrowError();
+  });
+});
+
+afterAll(() => {
+  fs.unlinkSync(path.join(testDir, "/package.json"));
+  fs.rmSync(mjsProjectPath, { recursive: true, force: true });
+  fs.rmSync(cjsProjectPath, { recursive: true, force: true });
+  fs.rmSync(tsProjectPath, { recursive: true, force: true });
+});

--- a/tests/globalSetupFiles.ts
+++ b/tests/globalSetupFiles.ts
@@ -1,0 +1,10 @@
+import * as fs from "fs";
+import { testDir } from "./constants";
+
+export async function setup() {
+  fs.mkdirSync(testDir);
+}
+
+export async function teardown() {
+  fs.rmSync(testDir, { recursive: true, force: true });
+}

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,11 @@
+import path from "path";
+import { fileURLToPath } from "url";
+import { describe, expect, it } from "vitest";
+import rootDir from "../utils/rootDir";
+
+describe("test utility functions", () => {
+  it.concurrent("should return root dirt", async () => {
+    const __filename = fileURLToPath(import.meta.url);
+    expect(rootDir).toBe(path.resolve(path.dirname(__filename), ".."));
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globalSetup: ["./tests/globalSetupFiles.ts"],
+    globals: true,
+  },
+});


### PR DESCRIPTION
closes #6 
## Additions
- Add Vitest as a testing suite
- create test files for utility functions and create project files functions
- add scripts in `package.json` to run the tests

## How to run
First, install all the new dependencies.
Second, run the script `test:dev` which will run tests in watch mode, or `test:ci` which will run tests once and exit.

## A new behavior
testing creates a temporary directory called `temp` under the `tests` folder in which all the test folders are created and tested.